### PR TITLE
Fix CSV loading for BOM

### DIFF
--- a/tcm_evaluation.py
+++ b/tcm_evaluation.py
@@ -129,7 +129,8 @@ class TCMEvaluationSystem:
     def load_dataset(self) -> pd.DataFrame:
         """載入中醫問答資料集"""
         try:
-            df = pd.read_csv(self.dataset_path, encoding='utf-8')
+            # 使用 utf-8-sig 以正確處理含 BOM 的 CSV 檔
+            df = pd.read_csv(self.dataset_path, encoding='utf-8-sig')
             self.logger.info(f"成功載入資料集，共 {len(df)} 筆題目")
             
             # 清理數據
@@ -826,7 +827,8 @@ class ModelComparator:
     
     def load_evaluation_results(self, result_file: str) -> List[EvaluationResult]:
         """載入評測結果"""
-        df = pd.read_csv(self.results_dir / result_file)
+        # 評測結果以 utf-8-sig 編碼保存，讀取時需指定相同編碼
+        df = pd.read_csv(self.results_dir / result_file, encoding='utf-8-sig')
         
         results = []
         for _, row in df.iterrows():


### PR DESCRIPTION
## Summary
- properly handle UTF-8 BOM when loading original dataset
- use the same encoding when reading evaluation result CSVs

## Testing
- `python - <<'PY'
from tcm_evaluation import TCMEvaluationSystem
sys = TCMEvaluationSystem(model_path='dummy', dataset_path='tcm_exam_question.csv', output_dir='test_output')
print(sys.dataset.columns.tolist()[:5])
res = sys.evaluate_sample(sample_size=3)
for r in res:
    print(r.question_id, r.model_answer, r.is_correct)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684da081cef0833280052c7c55911893